### PR TITLE
[NG] Remove console.log from forms layout service

### DIFF
--- a/src/clr-angular/forms/common/providers/layout.service.ts
+++ b/src/clr-angular/forms/common/providers/layout.service.ts
@@ -25,7 +25,6 @@ export class LayoutService {
   }
 
   isHorizontal(): boolean {
-    console.log(this.layout);
     return this.layout === Layouts.HORIZONTAL;
   }
 


### PR DESCRIPTION
Removed a left over `console.log` because it is spamming the browser console :-)

Signed-off-by: Gerd Jungbluth <gerd.jungbluth@engawa.de>